### PR TITLE
Update site domain to texttalk.abdullahtech.me

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,7 +32,7 @@ export function constructMetadata({
       title,
       description,
       type: 'website',
-      url: 'https://texttalk.techonline.live',
+      url: 'https://texttalk.abdullahtech.me',
       images: [
         {
           url: image,


### PR DESCRIPTION
Update the hardcoded OpenGraph URL in constructMetadata from the old domain (texttalk.techonline.live) to the new production domain (texttalk.abdullahtech.me) so social share metadata points to the correct site.